### PR TITLE
Remove reference to IETF from RFCs index.md

### DIFF
--- a/docs/development/rfc/index.md
+++ b/docs/development/rfc/index.md
@@ -4,7 +4,7 @@ title: Request for Comments
 
 # Request for Comments (RFC)
 
-An RFC is a memorandum describing methods, behaviors, research, or innovations applicable to the working of the Internet and Internet-connected systems. It is submitted either for peer review or simply to convey new concepts, information, or (occasionally) engineering humor. The IETF adopts some of the proposals published as RFCs as Internet standards.
+An RFC is a memorandum describing methods, behaviors, research, or innovations applicable to the working of the Internet and Internet-connected systems. It is submitted either for peer review or simply to convey new concepts, information, or (occasionally) engineering humor.
 
 An RFC describes a major change in the technological underpinnings of
 pygeoapi, major additions to functionality, or changes in the direction of


### PR DESCRIPTION
Removes the reference to IETF from the Request For Comments (RFC) index page. The next paragraph describes clearly how the RFCs relate to the project.