### PR TITLE
Invalid security certificate

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+pygeoapi.io


### PR DESCRIPTION
https://www.pygeoapi.io has an invalid security certificate due to the DNS setup for GitHub pages (e.g. when visiting the site with http**s** and **www** specified).

The other combinations for possible urls are working fine (and should continue to work with the changes below): http://pygeoapi.io, http://www.pygeoapi.io, https://pygeoapi.io

I believe this can be fixed by adding the `CNAME` text file in the root of the repository and changing the CNAME entry in the domains DNS to:   `CNAME`   with  `www`  pointing to `geopython.github.io`

Also check in the GitHub pages section of the settings page that the custom domain has been entered as `pygeoapi` and not `www.pygeoapi`.

You may need to wait 30 mins+ for the DNS to update.